### PR TITLE
Layout idee van de readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,80 +1,78 @@
-# stoplicht-communicatie-spec
+# Stoplicht Communicatie Specificatie
+
 Dit document beschrijft de communicatie tussen de kruispuntsimulatie en de controller van het stoplichtprobleem.
 
-## Onderdelen
-Het product van de opdracht bestaat uit 3 verschillende componenten. 
-Elk component is losjes aan de andere gekoppeld, 
-en de koppeling bestaat alleen uit communicatie zoals beschreven in deze standaard.
-Elk van de 3 onderdelen wordt apart geïmplementeerd door elke groepje. 
-Elk onderdeel is uitwisselbaar met een implementatie van een ander groepje.
+## Inleiding
 
-De Onderdelen zijn:
+- [Systeem Overzicht](#systeem-overzicht)
+  - [Controller](#controller)
+  - [Simulatie](#simulatie)
+  - [Regressie Tester](#regressie-tester)
+- [Communicatie](#communicatie)
+  - [Topics](#topics)
+- [Belangrijke Concepten](#belangrijke-concepten)
+  - [Stoplichten](#stoplichten)
+  - [Sensoren](#sensoren)
+- [Problemen met deze oplossing?](#problemen-met-deze-oplossing)
+
+## Systeem Overzicht
+
+Het product bestaat uit drie los gekoppelde componenten. Elk component wordt apart geïmplementeerd en is uitwisselbaar met implementaties van andere groepen.
+
 ### Controller
-De *controller* is verantwoordelijk voor de staat van de stoplichten. 
-Dit onderdeel probeert een optimale verkeer-flow te behalen, en ongelukken te voorkomen 
-(het liefst in omgekeerde volgorde qua prioriteit).
-Dit onderdeel leest de staat van alle sensoren, die gebruikt *kunnen* worden om realtime-besluiten te maken.
+
+De controller is verantwoordelijk voor de staat van de stoplichten. Dit onderdeel probeert een optimale verkeersdoorstroming te behalen en ongelukken te voorkomen (in die volgorde qua prioriteit). De controller leest de staat van alle sensoren voor realtime-besluitvorming.
 
 ### Simulatie
-De *simulatie* is verantwoordelijk voor het nabootsen van een reële verkeerssituatie.
-De simulatie bepaald het gedrag van het verkeer, beide van individuelen voertuigen, en de hoeveelheid.
-De simulatie weergeeft het verkeer en de staat van de stoplichten etc.
-De simulatie is verantwoordelijk voor de staat van de sensoren (stoplicht sensoren, en speciale sensoren).
 
-### Regressie tester
-De *regressie tester* luistert naar alle communicatie tussen de [*controller*](#controller) en de [*simulatie*](#simulatie),
-en geeft een waarschuwing als de communicatie niet volgens het protocol gaat 
-(verkeerd JSON-formaat, topic wordt niet gepublished, topic bevat extra informatie, topic mist informatie, waarde in topic is niet mogelijk).
-De regressie tester heeft absoluut geen invloed op het gedrag van de andere componenten.
+De simulatie is verantwoordelijk voor het nabootsen van een reële verkeerssituatie. Het bepaalt het gedrag van individuele voertuigen en de verkeersdichtheid. De simulatie toont het verkeer en de staat van de stoplichten, en beheert de sensoren (stoplicht sensoren en speciale sensoren).
+
+### Regressie Tester
+
+De regressie tester valideert de communicatie tussen de controller en simulatie. Het geeft waarschuwingen bij protocol schendingen (verkeerd JSON-formaat, ontbrekende topics, ongeldige waarden). De tester heeft geen invloed op het systeemgedrag.
 
 ## Communicatie
-De communicatie tussen de [onderdelen](#onderdelen) gaat via [ZeroMQ](./zeromq/README.md),
-met gebruik van het [PUB/SUB-patroon](./zeromq/README.md#publish---subscribe).
-De communicatie gaat via een aantal topics. 
-Elk topic heeft één publisher, de [controller](#controller) of de [simulatie](#simulatie), 
-en de andere twee [onderdelen](#onderdelen) subscriben op deze topic. 
-De [regressie tester](#regressie-tester) subscribed dus op alle topics.
-De topics staat beschreven in [topics](./topics/README.md), 
-waar voor elke topic een specificatie en voorbeeld beschikbaar zijn.
- 
-## Concepten
+
+De componenten communiceren via ZeroMQ met het PUB/SUB-patroon. Elke topic heeft één publisher (controller of simulatie) en twee subscribers. De regressie tester luistert naar alle topics.
+
+### Topics
+
+De communicatie verloopt via verschillende topics:
+
+- Stoplichten: Status updates van verkeerslichten
+- Sensoren:
+  - Rijbaan sensoren: Voertuigdetectie per rijbaan
+  - Brug sensoren: Monitoring van bruggebied
+  - Speciale sensoren: Specifieke gebiedsmonitoring
+- Tijd: Synchronisatie en timing informatie
+- Voorrangsvoertuig: Prioriteitsverkeer meldingen
+
+Zie [Communicatie Protocol](./zeromq/README.md) voor implementatiedetails en [Topics](./topics/README.md) voor berichtformaten.
+
+## Belangrijke Concepten
 
 ### Stoplichten
-Een stoplicht wordt geïdentificeerd met een string in het format `"g.l"`, 
-waar `g` voor group (groep) staat, en `l` voor lane (baan).
-De locatie van de stoplichten staan beschreven in [kruispunt_verkeerslichten.png](./assets/Kruispunt_verkeerslichten.png)
-en [brug_verkeerslichten.png](./assets/Brug_verkeerslichten.png)
 
-Elk stoplicht heeft een staat, die kan zijn: `"groen"|"oranje"|"rood"`. 
-Deze staat wordt bepaald door de [controller](#controller), en weergeven en aangehouden door de [simulatie](#simulatie).
-
-De stoplichten 61-64 zijn hefbomen voor de brug.
-
-Els stoplicht heeft 2 sensoren (hoewel de tweede niet altijd wordt gebruikt).
-De eerste ligt vlag voor de stopstreep van het stoplicht, en de tweede ligt 35 meter daar achter.
-Deze sensoren geven aan of er voertuigen wachten op dat stoplicht, of er toevallig overheen rijden.
-
-Er is een heelhoop informatie beschikbaar over de stoplichten in [intersection data](./intersectionData/README.md) beschikbaar.
-Deze informatie *mag* gebruikt worden door de [controller](#controller).
+- Identificatie: `"groep.baan"` formaat
+- Staten: `"groen"|"oranje"|"rood"`
+- Locaties: Zie [kruispunt_verkeerslichten.png](./assets/Kruispunt_verkeerslichten.png) en [brug_verkeerslichten.png](./assets/Brug_verkeerslichten.png)
+- Sensoren: Twee per stoplicht (voor en 35m achter de stopstreep)
+- Stoplichten 61-64 zijn hefbomen voor de brug
+- Configuratie: Zie [intersection data](./intersectionData/README.md) voor gedetailleerde informatie over rijbanen en stoplichten
 
 ### Sensoren
-Er zijn 2 type sensoren: verkeerslicht sensoren (al gedeeltelijk besproken in [de kop hierboven](#stoplichten)), en *speciale sensoren*.
 
-Speciale sensoren zijn niet direct aan één wegdek te koppelen.
-Deze sensoren geven aan of er een voertuig in gebied zit. (Zie [[brug_verkeerslichten_senoren.svg](./assets/Brug_verkeerslichten_sensoren.svg)])
-voor het gebied. De controller kan deze sonoren gebruiken om regels toe te passen zoals:
-- De hefbomen mogen niet dicht als er een voertuig op het wegdek van de brug is
-- Vortuigen die de oost richting van de Damenlaan op willen, moeten wachten tot er geen file voor de brug is, of de brug open staat.
-
-Deze speciale regels zijn ook inbegrepen in het [Intersection_data JSON-bestand](./intersectionData/README.md)
-
+- Stoplicht sensoren: Detecteren voertuigen bij stoplichten
+- Speciale sensoren: Monitoren specifieke gebieden (zie [brug_verkeerslichten_sensoren.svg](./assets/Brug_verkeerslichten_sensoren.svg))
+  - Voorkomen dat hefbomen sluiten met voertuigen op de brug
+  - Regelen verkeer naar de Damenlaan bij brugfiles
+- Sensor configuratie: Gedetailleerde informatie beschikbaar in [intersection data](./intersectionData/README.md)
 
 # Problemen met deze oplossing?
-- Als je een verandering wilt zien in wat de afspraken zijn, of daar een vraag over hebt, maak een [issue](https://github.com/jorrit200/stoplicht-communicatie-spec/issues) aan.
-- Als je denkt dat deze spec afwijkt van een gemaakte afspraak, of dat een gemaakte afspraak nog niet geïmplementeerd is, maak een [pull-request](https://github.com/jorrit200/stoplicht-communicatie-spec/pulls) aan.
-- communiceer het naar de anderen in discord of de lessen.
-- veranderingen worden democratisch behandeld. Finale besluitvorming gebeurt altijd in een vergadering
 
-Het huidige communicatie protocol mag gezien worden als finaal, 
-en kan alleen aangepast worden als blijkt dat het protocol in strijd staat met gemaakte afspraken, 
-of het de implementatie van één of meer [onderdelen](#onderdelen) bijzonder (onnodig) moeilijk maakt (geldt niet voor specifiek implementaties).
+- Als je een verandering wilt zien in wat de afspraken zijn, of daar een vraag over hebt, maak een [issue](https://github.com/jorrit200/stoplicht-communicatie-spec/issues) aan
+- Als je denkt dat deze spec afwijkt van een gemaakte afspraak, of dat een gemaakte afspraak nog niet geïmplementeerd is, maak een [pull-request](https://github.com/jorrit200/stoplicht-communicatie-spec/pulls) aan
+- Communiceer het naar de anderen in Discord of de lessen
+- Veranderingen worden democratisch behandeld. Finale besluitvorming gebeurt altijd in een vergadering
+
+Het huidige communicatie protocol mag gezien worden als finaal, en kan alleen aangepast worden als blijkt dat het protocol in strijd staat met gemaakte afspraken, of het de implementatie van één of meer componenten bijzonder (onnodig) moeilijk maakt.


### PR DESCRIPTION
Mijn idee om het document met een inleiding te hebben en dit uit te werken om makkelijker naar juiste gedeelte van readme te gaan en in de tekst zelf links naar de folders binnen de repo.

Plus tekst wat korter gemaakt omdat meer details verwerkt kunnen worden binnen de repo buiten de readme om.

